### PR TITLE
fix: fix the wrong error return value

### DIFF
--- a/apps/erc20/erc20.go
+++ b/apps/erc20/erc20.go
@@ -208,7 +208,7 @@ func (e *ERC20) SyncSendRawTransactionForTx(
 	select {
 	case result := <-ch:
 		if result.err != nil {
-			return nil, err
+			return nil, result.err
 		}
 
 		return result.ret, nil
@@ -270,7 +270,7 @@ func (e *ERC20) SyncSendEIP1559Tx(
 	select {
 	case result := <-ch:
 		if result.err != nil {
-			return nil, err
+			return nil, result.err
 		}
 
 		return result.ret, nil

--- a/apps/erc721/erc721.go
+++ b/apps/erc721/erc721.go
@@ -233,7 +233,7 @@ func (e *ERC721) SyncSendEIP1559Tx(
 	select {
 	case result := <-ch:
 		if result.err != nil {
-			return nil, err
+			return nil, result.err
 		}
 
 		return result.ret, nil
@@ -290,7 +290,7 @@ func (e *ERC721) SyncSendRawTransactionForTx(
 	select {
 	case result := <-ch:
 		if result.err != nil {
-			return nil, err
+			return nil, result.err
 		}
 
 		return result.ret, nil

--- a/apps/weth/weth.go
+++ b/apps/weth/weth.go
@@ -204,7 +204,7 @@ func (e *WETH) SyncSendRawTransactionForTx(
 	select {
 	case result := <-ch:
 		if result.err != nil {
-			return nil, err
+			return nil, result.err
 		}
 
 		return result.ret, nil
@@ -265,7 +265,7 @@ func (e *WETH) SyncSendEIP1559Tx(
 	select {
 	case result := <-ch:
 		if result.err != nil {
-			return nil, err
+			return nil, result.err
 		}
 
 		return result.ret, nil


### PR DESCRIPTION
In fact, err is incorrect and should be   `result.err`